### PR TITLE
Update elvish config path

### DIFF
--- a/chain.org
+++ b/chain.org
@@ -45,9 +45,9 @@ To use this theme, first install the [[https://github.com/zzamboni/elvish-themes
 epm:install github.com/zzamboni/elvish-themes
 #+end_src
 
-You can do this interactively or from your =~/.elvish/rc.elv= file. If you want to put this in your =rc.elv= so that the package is automatically installed when needed, and avoid having a message printed every time the shell starts, you can add the =&silent-if-installed=$true= option to the above command.
+You can do this interactively or from your =~/.config/elvish/rc.elv= file. If you want to put this in your =rc.elv= so that the package is automatically installed when needed, and avoid having a message printed every time the shell starts, you can add the =&silent-if-installed=$true= option to the above command.
 
-Add the following to you =~/.elvish/rc.elv= file to load and configure the theme:
+Add the following to you =~/.config/elvish/rc.elv= file to load and configure the theme:
 
 *Note:* You have to call =chain:init= to set up the prompt, just loading the module does not configure it.
 
@@ -131,7 +131,7 @@ chain:space-after-arrow = $false
 
 This module also includes the =chain:summary-status= function, which provides a status summary of git repositories, using the =git-combined=, =git-branch= and =git-timestamp= segments. The list is presented in reverse chronological order according to their latest git commit (only if your version of Elvish supports the =order= builtin). I use this to get a quick summary of the status of my most commonly-used repos. The repositories to display can be provided in mutliple ways (if more than one is specified, the first one found is used):
 
-- Default behavior when no arguments nor options are given: read from a JSON file specified in =$chain:summary-repos-file= (default value: =~/.elvish/package-data/elvish-themes/chain-summary-repos.json=). The contents of this file can be manipulated using the =chain:add-summary-repo= and =chain:remove-summary-repo= functions (see example below).
+- Default behavior when no arguments nor options are given: read from a JSON file specified in =$chain:summary-repos-file= (default value: =~/.config/elvish/package-data/elvish-themes/chain-summary-repos.json=). The contents of this file can be manipulated using the =chain:add-summary-repo= and =chain:remove-summary-repo= functions (see example below).
 - As arguments to the function, e.g. =chain:summary-status dir1 dir2=.
 - All the git repos inside your home directory: =chain:summary-status &all=. Note: this uses the =fd= command by default, can be changed by storing the new function in =$chain:find-all-user-repos=. Default value:
   #+begin_src elvish :tangle no
@@ -157,13 +157,13 @@ Repo /Users/taazadi1/.hammerspoon added to the list
 [2020-05-27] [OK] [⎇ master] ~/.emacs.d
 [2020-05-22] [OK] [⎇ master] ~/.hammerspoon
 
-[~/.elvish]─[⎇ master]─> chain:summary-status ~/.elvish/lib/github.com/zzamboni/*
-[2020-05-09] [OK] [⎇ master] ~/.elvish/lib/github.com/zzamboni/elvish-completions
-[2020-05-08] [OK] [⎇ master] ~/.elvish/lib/github.com/zzamboni/elvish-modules
-[2020-05-22] [●] [⎇ master] ~/.elvish/lib/github.com/zzamboni/elvish-themes
+[~/.elvish]─[⎇ master]─> chain:summary-status ~/.config/elvishlib/github.com/zzamboni/*
+[2020-05-09] [OK] [⎇ master] ~/.config/elvishlib/github.com/zzamboni/elvish-completions
+[2020-05-08] [OK] [⎇ master] ~/.config/elvishlib/github.com/zzamboni/elvish-modules
+[2020-05-22] [●] [⎇ master] ~/.config/elvishlib/github.com/zzamboni/elvish-themes
 
-[~/.elvish]─[⎇ master]─> chain:summary-status &only-dirty ~/.elvish/lib/github.com/zzamboni/*
-[2020-05-22] [●] [⎇ master] ~/.elvish/lib/github.com/zzamboni/elvish-themes
+[~/.elvish]─[⎇ master]─> chain:summary-status &only-dirty ~/.config/elvishlib/github.com/zzamboni/*
+[2020-05-22] [●] [⎇ master] ~/.config/elvishlib/github.com/zzamboni/elvish-themes
 #+end_src
 
 By default, a progress indicator is shown while the repository data is being collected. You can disable this by setting =$chain:summary-progress-indicator= to =$false=. The indicator characters to show can be customized by storing a string or list in =$chain:summary-progress-steps=.
@@ -660,7 +660,7 @@ Default setup function, assigning our functions to =edit:prompt= and =edit:rprom
   #+end_src
 - Read from a JSON file specified in =$chain:summary-repos-file=. Default value:
   #+begin_src elvish
-    var summary-repos-file = ~/.elvish/package-data/elvish-themes/chain-summary-repos.json
+    var summary-repos-file = ~/.config/elvishpackage-data/elvish-themes/chain-summary-repos.json
   #+end_src
   The contents of this file can be manipulated using the =chain:add-summary-repo= and =chain:remove-summary-repo=.
 


### PR DESCRIPTION
The latest versions of elvish have moved the files into the '$HOME/.config/elvish/' dir. This fixes the docs.

Pair with #14 (excuse 2 different PRs :smile: )